### PR TITLE
Adds an entry for the tags file into .gitignore, which is autogenerated by the plugin.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+doc/tags


### PR DESCRIPTION
The tags file shouldn't need to be hanging around or modified and pushed back to master by users, especially those using Pathogen. See: https://github.com/tpope/vim-pathogen/issues/issue/18
